### PR TITLE
Introduced null checking within ngOnDestroy() method of ModalComponent

### DIFF
--- a/src/ng2-bs3-modal/components/modal.ts
+++ b/src/ng2-bs3-modal/components/modal.ts
@@ -46,6 +46,7 @@ export class ModalComponent implements OnDestroy {
     }
 
     ngOnDestroy() {
+        if(this.$modal == null) return;
         this.$modal.data('bs.modal', null);
         this.$modal.remove();
     }


### PR DESCRIPTION
In RC1, ngOnDestroy can be called even when $modal is null, it's causing the router/app to break.
